### PR TITLE
Adjust cron interval to start job every day

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ services:
   worship-submissions-email-notification:
     image: lblod/worship-submissions-email-notification-service:latest
     environment:
-      RUN_INTERVAL: 5
+      RUN_INTERVAL: "0 10 * * *"
       OUTBOX_FOLDER_URI: "http://data.lblod.info/id/mail-folders/2"
       FROM_EMAIL_ADDRESS: "Agentschap Binnenlands Bestuur Vlaanderen <noreply-binnenland@vlaanderen.be>"
       WORSHIP_DECISIONS_APP_BASEURL: "https://databankerediensten.lokaalbestuur.vlaanderen.be/"
@@ -58,7 +58,7 @@ services:
 | MU_SPARQL_ENDPOINT        | The SPARQL endpoint URL for querying data                                                                        |         |         |
 | MU_SPARQL_UPDATEPOINT     | The SPARQL endpoint URL for performing SPARQL updates                                                            |         |         |
 | BCC_EMAIL_ADDRESSES       | Recipients of emails that should be in BCC (Blind Carbon Copy)                                                    |         |          |
-| RUN_INTERVAL              | How frequently the service should run to send email notifications (in minutes)                                   | 5       |          |
+| RUN_INTERVAL              | How frequently the service should run to send email notifications (every day at 10:00 minutes)                                   | 0 10 * * *       |          |
 | MAX_MESSAGE_AGE           | Maximum age of the messages requested from the API (in days)                                                     | 3       |          |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/app.js
+++ b/app.js
@@ -9,14 +9,14 @@ import {
 import { insertEmail } from "./utils/queries";
 
 const INTERVAL = process.env.RUN_INTERVAL
-  ? parseInt(process.env.RUN_INTERVAL)
-  : 5;
+  ? process.env.RUN_INTERVAL
+  : `0 10 * * *`;
 
-const job = new CronJob(`*/${INTERVAL} * * * *`, processSendNotifications);
+const job = new CronJob(INTERVAL, processSendNotifications);
 
 job.start();
 console.log(
-  `Registered a task for fetching and processing subscription notifications every ${INTERVAL} minutes`
+  `Registered a task for fetching and processing subscription notifications at ${new Date().toISOString()}`
 );
 
 app.use(


### PR DESCRIPTION
# Description
DL-5269

This PR adjusts the cron pattern to trigger the job every day at 10:00 am instead of every 5 minutes. 

- RUN_INTERVAL nows accept a cron interval instead of a number and expects a String type.
- The current date is now shown in the service.
- Updating the readme accordingly.


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related stack

- https://github.com/lblod/app-worship-decisions-database

# How to test 

1. Run the worship-decisions-database stack with the new image.
2. Set a cron interval any will do but I suggest using five minutes to speed up testing.
3. Every thing should run like before since it's a minor config change.

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

Release and Bump docker image in app-worship-decisions-database when merged

drc up -d worship-submission-email-notification-service